### PR TITLE
Add multi-user support with dashboard

### DIFF
--- a/client/src/AuthContext.tsx
+++ b/client/src/AuthContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useState } from 'react';
+
+export interface AuthUser {
+    id: number;
+    name: string;
+    role: string;
+    department?: string;
+}
+
+interface AuthCtx {
+    user: AuthUser | null;
+    setUser: (u: AuthUser | null) => void;
+}
+
+export const AuthContext = createContext<AuthCtx>({
+    user: null,
+    setUser: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+    const [user, setUser] = useState<AuthUser | null>(null);
+    return (
+        <AuthContext.Provider value={{ user, setUser }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};

--- a/client/src/MainRouter.tsx
+++ b/client/src/MainRouter.tsx
@@ -14,6 +14,7 @@ import { TrayAppPage } from './routes/TrayAppPage';
 import { ElectronEventEmitter } from './services/ElectronEventEmitter';
 import { mainStore } from './store/mainStore';
 import { useGoogleAnalytics } from './useGoogleAnalytics';
+import { AuthProvider } from './AuthContext';
 
 Settings.defaultLocale = 'en-GB';
 
@@ -39,7 +40,8 @@ export function MainRouter() {
 
     return (
         <ChartThemeProvider>
-            <RootProvider>
+            <AuthProvider>
+                <RootProvider>
                 <Routes>
                     {/* Main App with main store */}
                     <Route
@@ -71,7 +73,8 @@ export function MainRouter() {
                     {/* Fallback redirect to /app */}
                     <Route path="*" element={<Navigate to="/app" replace />} />
                 </Routes>
-            </RootProvider>
+                </RootProvider>
+            </AuthProvider>
         </ChartThemeProvider>
     );
 }

--- a/client/src/components/DepartmentDashboard/index.tsx
+++ b/client/src/components/DepartmentDashboard/index.tsx
@@ -1,0 +1,22 @@
+import { Box, Heading } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+
+export function DepartmentDashboard() {
+    const [data, setData] = useState<any>(null);
+
+    useEffect(() => {
+        fetch('/api/departments/current/stats')
+            .then((r) => r.json())
+            .then(setData)
+            .catch(() => {});
+    }, []);
+
+    return (
+        <Box p={4}>
+            <Heading size="md" mb={4}>
+                Department Dashboard
+            </Heading>
+            <pre>{JSON.stringify(data, null, 2)}</pre>
+        </Box>
+    );
+}

--- a/client/src/components/MainLayout/HeaderMenu.tsx
+++ b/client/src/components/MainLayout/HeaderMenu.tsx
@@ -4,25 +4,34 @@ import {
     AiOutlineQuestionCircle,
     AiOutlineSearch,
     AiOutlineSetting,
+    AiOutlineTeam,
 } from 'react-icons/ai';
 
 import { Box } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../../AuthContext';
 import { ColorModeSwitcher } from '../ColorModeSwitcher';
 import { Header } from '../Header/Header';
 import { MenuItem } from '../Header/MenuItem';
 
-export const HeaderMenu = () => (
-    <Header brandLinkProps={{ to: '/app/timeline', as: RouterLink }}>
-        <MenuItem to="/app/timeline" icon={<AiOutlineBars />} title="Timeline" />
-        <MenuItem to="/app/summary" icon={<AiOutlineAreaChart />} title="Summary" />
-        <MenuItem to="/app/search" icon={<AiOutlineSearch />} title="Search" />
-        <MenuItem to="/app/settings" icon={<AiOutlineSetting />} title="Settings" />
-        <MenuItem to="/app/support" icon={<AiOutlineQuestionCircle />} title="Support" />
-        <Box flex="1" />
+export const HeaderMenu = () => {
+    const { user } = useContext(AuthContext);
+    return (
+        <Header brandLinkProps={{ to: '/app/timeline', as: RouterLink }}>
+            <MenuItem to="/app/timeline" icon={<AiOutlineBars />} title="Timeline" />
+            <MenuItem to="/app/summary" icon={<AiOutlineAreaChart />} title="Summary" />
+            <MenuItem to="/app/search" icon={<AiOutlineSearch />} title="Search" />
+            {user?.role === 'head' && (
+                <MenuItem to="/app/department" icon={<AiOutlineTeam />} title="Dashboard" />
+            )}
+            <MenuItem to="/app/settings" icon={<AiOutlineSetting />} title="Settings" />
+            <MenuItem to="/app/support" icon={<AiOutlineQuestionCircle />} title="Support" />
+            <Box flex="1" />
 
-        <Box>
-            <ColorModeSwitcher />
-        </Box>
-    </Header>
-);
+            <Box>
+                <ColorModeSwitcher />
+            </Box>
+        </Header>
+    );
+};

--- a/client/src/routes/MainAppPage.tsx
+++ b/client/src/routes/MainAppPage.tsx
@@ -7,6 +7,7 @@ import { SummaryPage } from './SummaryPage';
 import { SupportPage } from './SupportPage';
 import { TimelinePage } from './TimelinePage';
 import { TrayAppPage } from './TrayAppPage';
+import { DepartmentDashboard } from '../components/DepartmentDashboard';
 
 export function MainAppPage() {
     return (
@@ -57,6 +58,14 @@ export function MainAppPage() {
                     element={
                         <ErrorBoundary key="search">
                             <SearchPage />
+                        </ErrorBoundary>
+                    }
+                />
+                <Route
+                    path="department"
+                    element={
+                        <ErrorBoundary key="department">
+                            <DepartmentDashboard />
                         </ErrorBoundary>
                     }
                 />

--- a/electron/package.json
+++ b/electron/package.json
@@ -60,7 +60,9 @@
         "moment": "2.30.1",
         "node-machine-id": "^1.1.12",
         "randomcolor": "0.6.2",
-        "url-parse": "^1.5.10"
+        "url-parse": "^1.5.10",
+        "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.0"
     },
     "devDependencies": {
         "@electron/notarize": "^2.5.0",

--- a/electron/src/__tests__/trackItem.db.test.ts
+++ b/electron/src/__tests__/trackItem.db.test.ts
@@ -32,6 +32,7 @@ const emptyData: Partial<TrackItem> = {
     color: null,
     url: null,
     taskName: TrackItemType.AppTrackItem,
+    userId: 1,
 };
 
 describe('trackItem.db', () => {

--- a/electron/src/__tests__/watchAndSetAppTrackItem.test.ts
+++ b/electron/src/__tests__/watchAndSetAppTrackItem.test.ts
@@ -32,6 +32,7 @@ const emptyData: Partial<TrackItem> = {
     color: null,
     url: null,
     taskName: TrackItemType.AppTrackItem,
+    userId: 1,
 };
 
 describe('watchAndSetLogTrackItem', () => {

--- a/electron/src/__tests__/watchAndSetLogTrackItem.test.ts
+++ b/electron/src/__tests__/watchAndSetLogTrackItem.test.ts
@@ -57,6 +57,7 @@ const emptyData: Partial<TrackItem> = {
     color: null,
     url: null,
     taskName: TrackItemType.LogTrackItem,
+    userId: 1,
 };
 
 describe('watchAndSetLogTrackItem', () => {

--- a/electron/src/__tests__/watchAndSetStatusTrackItem.test.ts
+++ b/electron/src/__tests__/watchAndSetStatusTrackItem.test.ts
@@ -31,6 +31,7 @@ const emptyData: Partial<TrackItem> = {
     color: null,
     url: null,
     taskName: TrackItemType.StatusTrackItem,
+    userId: 1,
 };
 
 describe('watchAndSetStatusTrackItem', () => {

--- a/electron/src/background/auth.ts
+++ b/electron/src/background/auth.ts
@@ -1,0 +1,29 @@
+import Store from 'electron-store';
+import jwt from 'jsonwebtoken';
+
+const store = new Store<{ token?: string; userId?: number }>();
+const SECRET = process.env['JWT_SECRET'] || 'secret';
+
+export function saveToken(token: string) {
+    store.set('token', token);
+    try {
+        const payload = jwt.verify(token, SECRET) as any;
+        if (payload && payload.sub) {
+            store.set('userId', Number(payload.sub));
+        }
+    } catch {
+        // ignore invalid token
+    }
+}
+
+export function getToken(): string | undefined {
+    return store.get('token');
+}
+
+export function getUserId(): number | undefined {
+    return store.get('userId');
+}
+
+export function setUserId(id: number) {
+    store.set('userId', id);
+}

--- a/electron/src/background/syncService.ts
+++ b/electron/src/background/syncService.ts
@@ -1,0 +1,31 @@
+import { dbClient } from '../drizzle/dbClient';
+import { getToken } from './auth';
+
+const SYNC_URL = process.env['SYNC_URL'] || 'https://example.com';
+
+export async function uploadTrackItems() {
+    const token = getToken();
+    if (!token) return;
+    const items = await dbClient.findAllFromLastHoursDb(24);
+    await fetch(`${SYNC_URL}/api/track-items`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(items),
+    });
+}
+
+export async function pullUpdates() {
+    const token = getToken();
+    if (!token) return;
+    const res = await fetch(`${SYNC_URL}/api/updates`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+        const updates = await res.json();
+        // handle updates - placeholder
+        console.debug('Received updates', updates);
+    }
+}

--- a/electron/src/background/watchTrackItems/watchAndSetAppTrackItem.ts
+++ b/electron/src/background/watchTrackItems/watchAndSetAppTrackItem.ts
@@ -1,5 +1,6 @@
 import { dbClient } from '../../drizzle/dbClient';
 import { NewTrackItem, TrackItem } from '../../drizzle/schema';
+import { getUserId } from '../auth';
 import { State } from '../../enums/state';
 import { TrackItemType } from '../../enums/track-item-type';
 
@@ -28,6 +29,7 @@ async function setAppTrackItem(activeWindow: NormalizedActiveWindow) {
         app: activeWindow.app,
         title: activeWindow.title,
         url: activeWindow.url,
+        userId: getUserId() ?? 1,
         beginDate: now,
         endDate: now,
     };
@@ -39,7 +41,13 @@ export async function getOngoingAppTrackItem() {
     }
 
     const color = await dbClient.getAppColor(currentAppItem?.app || '');
-    return { ...currentAppItem, endDate: Date.now(), id: 0, color } as TrackItem;
+    return {
+        ...currentAppItem,
+        endDate: Date.now(),
+        id: 0,
+        color,
+        userId: getUserId() ?? 1,
+    } as TrackItem;
 }
 
 const saveOngoingTrackItem = async () => {

--- a/electron/src/background/watchTrackItems/watchAndSetLogTrackItem.ts
+++ b/electron/src/background/watchTrackItems/watchAndSetLogTrackItem.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 import { TrackItemRaw } from '../../app/task-analyser.utils';
 import { dbClient } from '../../drizzle/dbClient';
 import { NewTrackItem, TrackItem } from '../../drizzle/schema';
+import { getUserId } from '../auth';
 import { State } from '../../enums/state';
 import { TrackItemType } from '../../enums/track-item-type';
 import { appEmitter } from '../../utils/appEmitter';
@@ -32,6 +33,7 @@ async function cutLogTrackItem(state: State) {
         const itemToInsert = {
             ...currentLogItem,
             endDate: now,
+            userId: getUserId() ?? 1,
         };
 
         await dbClient.insertTrackItemInternal(itemToInsert);
@@ -56,6 +58,7 @@ async function stopRunningLogTrackItem(endDate: number) {
     const itemToInsert = {
         ...currentLogItem,
         endDate,
+        userId: getUserId() ?? 1,
     };
 
     await dbClient.insertTrackItemInternal(itemToInsert);
@@ -74,6 +77,7 @@ async function createNewRunningLogTrackItem(rawItem: TrackItemRaw) {
         app: rawItem.app || 'unknown',
         title: rawItem.title || 'unknown',
         color: rawItem.color,
+        userId: getUserId() ?? 1,
         beginDate: now,
         endDate: now,
     };
@@ -88,7 +92,11 @@ export async function getOngoingLogTrackItem() {
         return null;
     }
 
-    return { ...currentLogItem, endDate: Date.now() } as TrackItem;
+    return {
+        ...currentLogItem,
+        endDate: Date.now(),
+        userId: getUserId() ?? 1,
+    } as TrackItem;
 }
 
 export async function watchAndSetLogTrackItem() {

--- a/electron/src/background/watchTrackItems/watchAndSetStatusTrackItem.ts
+++ b/electron/src/background/watchTrackItems/watchAndSetStatusTrackItem.ts
@@ -1,5 +1,6 @@
 import { dbClient } from '../../drizzle/dbClient';
 import { NewTrackItem, TrackItem } from '../../drizzle/schema';
+import { getUserId } from '../auth';
 import { State } from '../../enums/state';
 import { TrackItemType } from '../../enums/track-item-type';
 import { appEmitter } from '../../utils/appEmitter';
@@ -16,6 +17,7 @@ function makeStatusItem(state: State) {
         taskName: TrackItemType.StatusTrackItem,
         app: state,
         title: state.toString().toLowerCase(),
+        userId: getUserId() ?? 1,
         beginDate: now,
         endDate: now,
     };

--- a/electron/src/drizzle/schema.ts
+++ b/electron/src/drizzle/schema.ts
@@ -1,10 +1,28 @@
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
+export const users = sqliteTable(
+    'Users',
+    {
+        id: integer('id').primaryKey({ autoIncrement: true }),
+        name: text('name').notNull(),
+        department: text('department'),
+        role: text('role').notNull(),
+    },
+    (table) => ({
+        nameIdx: index('users_name').on(table.name),
+        deptIdx: index('users_department').on(table.department),
+        roleIdx: index('users_role').on(table.role),
+    }),
+);
+
 export const trackItems = sqliteTable(
     'TrackItems',
     {
         id: integer('id').primaryKey({ autoIncrement: true }),
         app: text('app').notNull(),
+        userId: integer('user_id')
+            .notNull()
+            .references(() => users.id, { onDelete: 'cascade' }),
         taskName: text('taskName'),
         title: text('title'),
         url: text('url'),
@@ -52,6 +70,9 @@ export const settings = sqliteTable(
 
 export type TrackItem = typeof trackItems.$inferSelect;
 export type NewTrackItem = typeof trackItems.$inferInsert;
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
 
 export type AppSetting = typeof appSettings.$inferSelect;
 export type NewAppSetting = typeof appSettings.$inferInsert;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+// Dummy middlewares for auth & roles
+function requireRole(role: string) {
+    return (req: any, res: any, next: any) => {
+        const user = (req as any).user || {};
+        if (user.role !== role) {
+            return res.status(403).send('Forbidden');
+        }
+        next();
+    };
+}
+
+app.get('/api/users/:id/summary', (req, res) => {
+    res.json({ id: req.params.id, summary: {} });
+});
+
+app.get('/api/departments/:dept/stats', requireRole('head'), (req, res) => {
+    res.json({ department: req.params.dept, stats: {} });
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- add new `users` table and userId FK on `trackItems`
- include authentication helper and sync service for backend
- support userId in watchTrackItem jobs
- expose basic Express server endpoints
- create React auth context and department dashboard
- show dashboard link for department heads
- update tests for userId field

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in client *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651f165ce083258b0f6ac39523d4e7